### PR TITLE
名前の文字数が多くなりすぎたときにあふれた分を表示されないようにしました

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -302,7 +302,8 @@ header .title {
 }
 
 .user-circle {
-
+  overflow: hidden;
+  max-width: 30%;
   height: 70px;
   border-radius: 20px;
   background-color: #eeeeee;


### PR DESCRIPTION
max-widthに変更したので固定の位置などあればまた変更します